### PR TITLE
Fix PAT example to use OAuth client credentials flow

### DIFF
--- a/authentication/personal-access-token/.env.example
+++ b/authentication/personal-access-token/.env.example
@@ -1,6 +1,6 @@
 # Base Url endpoint
 BASE_URL = 'https://api-sandbox.uphold.com'
 
-USERNAME = 'my_registration_email@domain.com'
-PASSWORD = 'my_password_in_clear_text'
+CLIENT_ID = 'my_application_client_id'
+CLIENT_SECRET = 'my_application_client_secret'
 PAT_DESCRIPTION = 'Put a Description Here'

--- a/authentication/personal-access-token/README.md
+++ b/authentication/personal-access-token/README.md
@@ -9,11 +9,17 @@ For further background, please refer to the [API documentation](https://uphold.c
 
 This sample project performs the following actions:
 
+- Obtain an OAuth access token using the client credentials grant
 - Create a new PAT
 - List all created PATs associated to this account
 
 **Important notice:** If the account has two-factor authentication (2FA) active, a one-time-password (OTP) must be passed when creating PATs.
 In the Sandbox environment, the special OTP value `000000` can be passed for convenience, as can be seen in the `index.js` file. In production, you would need to use an actual TOTP code provided by your chosen authenticator app (e.g. Google Authenticator).
+
+**Note:** In Uphold's production environment, client credentials authentication is only available for **business accounts** and requires approval from Uphold.
+Please [contact Uphold](mailto:developer@uphold.com) to obtain this permission.
+For requests made in the sandbox environment, as is the case with this demo project, those requirements can be skipped.
+If you are building a production integration for a personal account, you may need to use a different OAuth flow, such as `authorization_code`, instead of `client_credentials`.
 
 ## Requirements
 
@@ -23,6 +29,7 @@ In the Sandbox environment, the special OTP value `000000` can be passed for con
 ## Setup
 
 - Run `npm install` (or `yarn install`).
+- [Create an app on Uphold Sandbox](https://sandbox.uphold.com/dashboard/profile/applications/developer/new) and note its client ID and secret.
 - Create a `.env` file based on the `.env.example` file, and populate it with the required data.
 
 ## Run

--- a/authentication/personal-access-token/index.js
+++ b/authentication/personal-access-token/index.js
@@ -2,7 +2,7 @@
  * Dependencies.
  */
 
-import { createNewPAT, getAuthenticationMethods, getUserPATs } from "./personal-access-token.js";
+import { createNewPAT, getAccessToken, getAuthenticationMethods, getUserPATs } from "./personal-access-token.js";
 import fs from "fs";
 
 (async () => {
@@ -13,8 +13,12 @@ import fs from "fs";
   }
 
   try {
+    // Obtain an OAuth access token using client credentials.
+    const accessToken = await getAccessToken();
+    console.log("Successfully obtained an OAuth access token.");
+
     // Get list of authentication methods.
-    const authMethods = await getAuthenticationMethods();
+    const authMethods = await getAuthenticationMethods(accessToken);
 
     // In the Sandbox environment, the special OTP value `000000` can be passed for convenience.
     const totp = {
@@ -31,7 +35,7 @@ import fs from "fs";
     }
 
     // Get a new Personal Access Token (PAT).
-    const token = await createNewPAT(totp);
+    const token = await createNewPAT(accessToken, totp);
     console.log("Successfully obtained a new Personal Access Token (PAT):", token.accessToken);
 
     // Test the new token by making an authenticated call to the API.

--- a/authentication/personal-access-token/personal-access-token.js
+++ b/authentication/personal-access-token/personal-access-token.js
@@ -9,9 +9,6 @@ import path from "path";
 // Dotenv configuration.
 dotenv.config({ path: path.resolve() + "/.env" });
 
-// Authentication credentials.
-const auth = Buffer.from(process.env.USERNAME + ":" + process.env.PASSWORD).toString("base64");
-
 /**
  * Format API error response for printing in console.
  */
@@ -31,16 +28,40 @@ function formatError(error) {
 }
 
 /**
- * Get list of authentication methods, using basic authentication (username and password).
+ * Obtain an OAuth access token using the client credentials grant.
  */
 
-export async function getAuthenticationMethods() {
+export async function getAccessToken() {
+  const auth = Buffer.from(`${process.env.CLIENT_ID}:${process.env.CLIENT_SECRET}`).toString("base64");
+
+  try {
+    const response = await axios.request({
+      method: "POST",
+      url: `${process.env.BASE_URL}/oauth2/token`,
+      headers: {
+        Authorization: `Basic ${auth}`,
+        "content-type": "application/x-www-form-urlencoded",
+      },
+      data: "grant_type=client_credentials",
+    });
+
+    return response.data.access_token;
+  } catch (error) {
+    formatError(error);
+  }
+}
+
+/**
+ * Get list of authentication methods, using an OAuth bearer token.
+ */
+
+export async function getAuthenticationMethods(accessToken) {
   try {
     const response = await axios.request({
       method: "GET",
       url: `${process.env.BASE_URL}/v0/me/authentication_methods`,
       headers: {
-        Authorization: `Basic ${auth}`,
+        Authorization: `Bearer ${accessToken}`,
       },
     });
 
@@ -51,14 +72,14 @@ export async function getAuthenticationMethods() {
 }
 
 /**
- * Create a Personal Access Token (PAT), using basic authentication (username and password).
+ * Create a Personal Access Token (PAT), using an OAuth bearer token.
  * The time-based one-time password (TOTP) parameter
  * is typically provided by an OTP application, e.g. Google Authenticator.
  */
 
-export async function createNewPAT(totp) {
+export async function createNewPAT(accessToken, totp) {
   const headers = {
-    Authorization: `Basic ${auth}`,
+    Authorization: `Bearer ${accessToken}`,
     "content-type": "application/json",
   };
 


### PR DESCRIPTION
## Summary
- The `POST /v0/me/tokens` endpoint does not support Basic Auth (email:password) authentication, causing the PAT creation example to fail with a 401 Unauthorized error
- Replace the Basic Auth flow with the OAuth `client_credentials` grant to obtain a bearer token first, then use it to create the PAT
- Update `.env.example` to use `CLIENT_ID` and `CLIENT_SECRET` instead of `USERNAME` and `PASSWORD`
- Update README with setup instructions for creating an OAuth app

## Context
This was reported by a partner who followed the example and hit the 401. The backend removed Basic Auth support for `POST /v0/me/tokens` back in 2019 but these examples were never updated.

## Test plan
- [ ] Run the updated example against sandbox with valid client credentials
- [ ] Verify PAT is created successfully
- [ ] Verify the new PAT can be used to list tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)